### PR TITLE
fix(annotations): added missing @class

### DIFF
--- a/lua/mega/logging.lua
+++ b/lua/mega/logging.lua
@@ -117,6 +117,7 @@ local _ROOT_NAME = "__ROOT__"
 ---@type table<string, mega.logging.Logger>
 M._LOGGERS = {}
 
+---@class mega.logging.Logger
 M.Logger = {
     __tostring = function(logger)
         return string.format("mega.logging.Logger({names=%s})", vim.inspect(logger.name))


### PR DESCRIPTION
This PR fixes https://github.com/ColinKennedy/nvim-best-practices-plugin-template/actions/runs/12727291058/job/35476659758?pr=38, where it looks like Logger was untyped, which causes llscheck to fail in downstream lua libraries.