### PR TITLE
doc(vim): removed functions that were meant to be private

### DIFF
--- a/doc/mega_logging_api.txt
+++ b/doc/mega_logging_api.txt
@@ -10,7 +10,7 @@ Fields ~
     {float_precision} `(number?)`
        A positive value (max of 1) to indicate the rounding precision. e.g.
        0.01 rounds to every hundredths.
-    {level} ("trace" | "debug" | "info" | "warn" | "error" | "fatal")?
+    {level} "trace" | "debug" | "info" | "warn" | "error" | "fatal"?
        The minimum severity needed for this logger instance to output a log.
     {name} `(string?)`
        An identifier for this logger.
@@ -53,12 +53,9 @@ Fields ~
        within a libuv thread and don't want to call `vim.schedule()`.
 
 ------------------------------------------------------------------------------
-                                                                      *_OPTIONS*
+                                                           *mega.logging.Logger*
 
-`_OPTIONS`
-
-Type ~
-`(table<string, mega.logging.SparseLoggerOptions>)`
+`mega.logging.Logger`
 
 ------------------------------------------------------------------------------
                                                            *mega.logging.Logger*
@@ -186,33 +183,6 @@ Return ~
 
 Return ~
     `(string)` `(optional)` The path on-disk where logs will be written to.
-
-------------------------------------------------------------------------------
-                                                 *_P.get_parent_configuration()*
-
-`_P.get_parent_configuration`({logger})
-
-Gather all data above `logger`.
-
-Important:
-    This function is *exclusive* - it does not include any sparse options
-    of `logger` itself, just its parents.
-
-Parameters ~
-    {logger} mega.logging.Logger The logger to start searching from.
-
-Return ~
-    mega.logging.SparseLoggerOptions All found options, if `(any.)`
-
-------------------------------------------------------------------------------
-                                                        *_P.recompute_loggers()*
-
-`_P.recompute_loggers`({name})
-
-Find and re-apply all configurations for all loggers starting with `name`.
-
-Parameters ~
-    {name} `(string)` A starting point. e.g. `"foo.bar"`.
 
 ------------------------------------------------------------------------------
                                                      *mega.logging.get_logger()*

--- a/doc/tags
+++ b/doc/tags
@@ -1,7 +1,3 @@
-_OPTIONS	mega_logging_api.txt	/*_OPTIONS*
-_P.get_parent_configuration()	mega_logging_api.txt	/*_P.get_parent_configuration()*
-_P.recompute_loggers()	mega_logging_api.txt	/*_P.recompute_loggers()*
-exclusive	mega_logging_api.txt	/*exclusive*
 mega.logging-a-neovim-logger	mega.logging.txt	/*mega.logging-a-neovim-logger*
 mega.logging-installation	mega.logging.txt	/*mega.logging-installation*
 mega.logging-new-breaking	news.txt	/*mega.logging-new-breaking*

--- a/lua/mega/logging.lua
+++ b/lua/mega/logging.lua
@@ -3,12 +3,14 @@
 ---@module 'mega.logging'
 ---
 
+---@alias _Level "trace" | "debug" | "info" | "warn" | "error" | "fatal"
+
 ---@class mega.logging.SparseLoggerOptions
 ---    All of the customizations a person can make to a logger instance.
 ---@field float_precision number?
 ---    A positive value (max of 1) to indicate the rounding precision. e.g.
 ---    0.01 rounds to every hundredths.
----@field level ("trace" | "debug" | "info" | "warn" | "error" | "fatal")?
+---@field level _Level?
 ---    The minimum severity needed for this logger instance to output a log.
 ---@field name string?
 ---    An identifier for this logger.
@@ -30,7 +32,7 @@
 ---@field float_precision number
 ---    A positive value (max of 1) to indicate the rounding precision. e.g.
 ---    0.01 rounds to every hundredths.
----@field level "trace" | "debug" | "info" | "warn" | "error" | "fatal"
+---@field level _Level
 ---    The minimum severity needed for this logger instance to output a log.
 ---@field name string
 ---    An identifier for this logger.
@@ -64,6 +66,7 @@ local _LOGGER_HIERARCHY_SEPARATOR = "."
 local _LEVELS = { trace = 10, debug = 20, info = 30, warn = 40, error = 50, fatal = 60 }
 
 ---@type table<string, mega.logging.SparseLoggerOptions>
+---@private
 local _OPTIONS = {}
 
 --- Suggest a default level for all loggers.
@@ -429,6 +432,7 @@ end
 ---
 ---@param logger mega.logging.Logger The logger to start searching from.
 ---@return mega.logging.SparseLoggerOptions # All found options, if any.
+---@private
 ---
 function _P.get_parent_configuration(logger)
     local parts = vim.fn.split(logger.name, "\\.")
@@ -453,6 +457,7 @@ end
 --- Find and re-apply all configurations for all loggers starting with `name`.
 ---
 ---@param name string A starting point. e.g. `"foo.bar"`.
+---@private
 ---
 function _P.recompute_loggers(name)
     for _, logger in pairs(M._LOGGERS) do


### PR DESCRIPTION
- Removed functions from documentation that were meant to be private
- Added an alias to make code a bit easier to understand
- vimtags are fixed again